### PR TITLE
Add NOC dashboard route

### DIFF
--- a/apps/dashboard/public/NOC/index.html
+++ b/apps/dashboard/public/NOC/index.html
@@ -1,0 +1,254 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SMW NOC Dashboard | Ops Engine</title>
+  <link rel="stylesheet" href="/ops-page/ops-page.css" />
+</head>
+<body>
+  <main>
+    <header class="hero">
+      <div>
+        <p class="eyebrow">Network Operations Center</p>
+        <h1>SMW NOC Dashboard</h1>
+        <p class="subtitle">Availability and infrastructure monitoring for sunnysir.com: uptime, service health, server resources, database status, Celery/Redis queues, backups, deployment state, latency, and operational incidents.</p>
+        <nav class="nav">
+          <a href="/">Mission Control</a>
+          <a href="/SOC">SOC</a>
+          <a href="/NOC">NOC</a>
+          <a href="#services">Services</a>
+          <a href="#resources">Resources</a>
+          <a href="#database">Database</a>
+          <a href="#queue">Queue</a>
+          <a href="#incidents">Incidents</a>
+        </nav>
+      </div>
+      <button id="refreshBtn">↻ Refresh</button>
+    </header>
+
+    <div id="error" class="banner"></div>
+
+    <section class="section" id="overview">
+      <div class="section-head">
+        <p class="eyebrow">Production posture</p>
+        <h2>NOC overview</h2>
+        <p id="heartbeatMeta" class="small muted">Loading heartbeat…</p>
+      </div>
+      <div class="grid metrics" id="metrics"></div>
+    </section>
+
+    <section class="section" id="resources">
+      <div class="section-head">
+        <p class="eyebrow">Infrastructure trends</p>
+        <h2>Server resource trends</h2>
+      </div>
+      <div class="grid three">
+        <div id="diskSpark"></div>
+        <div id="memorySpark"></div>
+        <div id="loadSpark"></div>
+      </div>
+    </section>
+
+    <section class="section" id="availability">
+      <div class="section-head">
+        <p class="eyebrow">Availability</p>
+        <h2>Uptime and traffic health</h2>
+      </div>
+      <div class="grid two">
+        <div class="card">
+          <div class="card-head"><div><p class="eyebrow">Uptime checks</p><h3>Recent targets</h3></div></div>
+          <div class="status-list" id="uptimeList"></div>
+        </div>
+        <div class="card">
+          <div class="card-head"><div><p class="eyebrow">Traffic</p><h3>Requests and 5xx trends</h3></div></div>
+          <div class="grid two">
+            <div id="requestSpark"></div>
+            <div id="fiveSpark"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="services">
+      <div class="section-head">
+        <p class="eyebrow">Service health</p>
+        <h2>Systemd and PM2 services</h2>
+      </div>
+      <div class="grid two">
+        <div class="card">
+          <div class="card-head"><div><p class="eyebrow">Critical path</p><h3>Core services</h3></div></div>
+          <div class="status-list" id="criticalServices"></div>
+        </div>
+        <div class="card">
+          <div class="card-head"><div><p class="eyebrow">All services</p><h3>Latest snapshots</h3></div></div>
+          <div class="status-list" id="serviceList"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="database">
+      <div class="section-head">
+        <p class="eyebrow">Database operations</p>
+        <h2>PostgreSQL health</h2>
+      </div>
+      <div class="grid four" id="databaseCards"></div>
+    </section>
+
+    <section class="section" id="queue">
+      <div class="section-head">
+        <p class="eyebrow">Worker operations</p>
+        <h2>Celery and Redis queue health</h2>
+      </div>
+      <div class="grid three" id="queueCards"></div>
+      <div class="card" style="margin-top:14px">
+        <div class="card-head"><div><p class="eyebrow">Queues</p><h3>Depth by queue</h3></div></div>
+        <div class="bars" id="queueBars"></div>
+      </div>
+    </section>
+
+    <section class="section" id="deployment">
+      <div class="section-head">
+        <p class="eyebrow">Deployment</p>
+        <h2>Current release state</h2>
+      </div>
+      <div class="grid four" id="deployCards"></div>
+    </section>
+
+    <section class="section" id="incidents">
+      <div class="section-head">
+        <p class="eyebrow">Operations response</p>
+        <h2>Incidents and backup status</h2>
+      </div>
+      <div class="grid two">
+        <div class="card">
+          <div class="card-head"><div><p class="eyebrow">Incidents</p><h3>Open incidents</h3></div></div>
+          <div class="status-list" id="incidentList"></div>
+        </div>
+        <div class="card">
+          <div class="card-head"><div><p class="eyebrow">Backups</p><h3>Latest backup check</h3></div></div>
+          <div class="grid three" id="backupCards"></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script src="/ops-page/ops-page.js"></script>
+  <script>
+    const O = OpsPage;
+    const criticalNames = ["nginx", "gunicorn-smw", "smw-frontend", "postgresql@16-main", "redis-server", "celery_smw", "celery-beat-smw"];
+
+    function serviceTone(status) { return O.statusClass(status); }
+    function queueTone(depth) { return O.n(depth) > 100 ? "bad" : O.n(depth) > 20 ? "warn" : "good"; }
+    function pctTone(value, warn, bad) { const v = O.n(value); return v >= bad ? "bad" : v >= warn ? "warn" : "good"; }
+    function backupTone(status, age) {
+      const s = String(status || "unknown").toLowerCase();
+      if (["ok", "live", "healthy"].includes(s)) return "good";
+      if (["stale", "warning"].includes(s)) return "warn";
+      if (O.n(age) >= 48 || ["critical", "missing", "error"].includes(s)) return "bad";
+      return O.statusClass(status);
+    }
+
+    async function load() {
+      O.$("refreshBtn").disabled = true;
+      O.$("error").style.display = "none";
+      try {
+        const { latest, services, history, incidents } = await O.loadBundle();
+        const heartbeat = latest.heartbeat || {};
+        const cc = latest.control_center || {};
+        const production = cc.production || {};
+        const database = cc.database || {};
+        const queue = cc.queue || {};
+        const deployment = cc.deployment || latest.deploy || {};
+        const server = latest.server || {};
+        const backup = latest.backup || {};
+        const apiTraffic = latest.api_traffic || {};
+        const uptimeRows = O.asArray(latest.uptime);
+        const serviceRows = O.asArray(services.services);
+        const incidentRows = O.asArray(latest.incidents || incidents.incidents);
+        const histServer = O.asArray(history.server);
+        const histTraffic = O.asArray(history.traffic);
+        const queues = queue.queues || {};
+
+        const smwStatus = String((production.smw || {}).status || heartbeat.status || "unknown");
+        const diskUsed = server.disk_used_pct ?? (production.resources || {}).disk_used_pct;
+        const memoryUsed = server.memory_used_pct ?? (production.resources || {}).memory_used_pct;
+        const total5xx = O.n(apiTraffic.total_5xx);
+        const queueDepth = O.n(queue.total_depth);
+        const backupAge = O.n(backup.latest_backup_age_hours, -1);
+        const unhealthyServices = serviceRows.filter(s => O.statusClass(s.status) === "bad").length;
+        const nocScore = Math.min(100,
+          (O.statusClass(smwStatus) === "bad" ? 35 : 0) +
+          unhealthyServices * 10 +
+          (O.n(diskUsed) >= 90 ? 20 : O.n(diskUsed) >= 80 ? 8 : 0) +
+          (O.n(memoryUsed) >= 95 ? 20 : O.n(memoryUsed) >= 85 ? 8 : 0) +
+          (queueDepth > 100 ? 20 : queueDepth > 20 ? 8 : 0) +
+          (backupAge >= 48 ? 20 : backupAge >= 24 ? 8 : 0) +
+          total5xx * 5 +
+          incidentRows.length * 20
+        );
+        const nocTone = nocScore >= 70 ? "bad" : nocScore >= 30 ? "warn" : "good";
+
+        O.$("heartbeatMeta").textContent = `Heartbeat ${O.ago(heartbeat.received_at)} · Source ${heartbeat.source || "unknown"} · API ${O.API_BASE}`;
+        O.$("metrics").innerHTML = [
+          O.metric("NOC risk score", `${nocScore}/100`, "Availability risk from services, resources, queue, backups, 5xx, and incidents.", nocTone),
+          O.metric("SMW status", smwStatus.toUpperCase(), `heartbeat ${O.ago(heartbeat.received_at)}`, O.statusClass(smwStatus)),
+          O.metric("Disk used", diskUsed != null ? `${diskUsed}%` : "—", `host ${server.hostname || heartbeat.hostname || "smw"}`, pctTone(diskUsed, 80, 90)),
+          O.metric("Memory used", memoryUsed != null ? `${memoryUsed}%` : "—", `${server.cpu_count || "—"} CPU cores`, pctTone(memoryUsed, 85, 95)),
+          O.metric("Queue depth", queueDepth, "Celery/Redis total depth", queueTone(queueDepth)),
+          O.metric("Open incidents", incidentRows.length, incidentRows.length ? "needs response" : "clear", incidentRows.length ? "bad" : "good"),
+        ].join("");
+
+        O.spark("diskSpark", "Disk used", histServer.map(x => O.n(x.disk_used_pct)), pctTone(diskUsed, 80, 90), "%");
+        O.spark("memorySpark", "Memory used", histServer.map(x => O.n(x.memory_used_pct)), pctTone(memoryUsed, 85, 95), "%");
+        O.spark("loadSpark", "Load 1m", histServer.map(x => O.n(x.load1)), "good", "");
+        O.spark("requestSpark", "Requests/window", histTraffic.map(x => O.n(x.total_requests)), "good", "");
+        O.spark("fiveSpark", "5xx/window", histTraffic.map(x => O.n(x.total_5xx)), total5xx ? "bad" : "good", "");
+
+        O.$("uptimeList").innerHTML = uptimeRows.length ? uptimeRows.slice(0, 10).map(row => O.statusRow(row.target_key || row.target_url || "target", row.ok ? "ok" : "down", `${row.status_code || "—"} · ${row.latency_ms || "—"}ms · ${O.ago(row.checked_at)}`)).join("") : O.statusRow("No uptime rows", "unknown", "waiting for worker schedule");
+
+        const critical = serviceRows.filter(s => criticalNames.includes(s.service_name));
+        O.$("criticalServices").innerHTML = critical.length ? critical.map(s => O.statusRow(s.service_name, s.status, O.ago(s.checked_at))).join("") : O.statusRow("No critical service rows", "unknown", "waiting for heartbeat");
+        O.$("serviceList").innerHTML = serviceRows.length ? serviceRows.slice(0, 16).map(s => O.statusRow(s.service_name, s.status, O.ago(s.checked_at))).join("") : O.statusRow("No service snapshots", "unknown", "waiting for heartbeat");
+
+        O.$("databaseCards").innerHTML = [
+          O.metric("DB status", database.status || "unknown", "Postgres collector", O.statusClass(database.status)),
+          O.metric("Connections", database.connections ?? "—", `active ${database.active_connections ?? "—"} · idle ${database.idle_connections ?? "—"}`, O.n(database.connections) > 80 ? "warn" : "good"),
+          O.metric("DB size", O.fmtBytes(database.database_size_bytes), "current database", "good"),
+          O.metric("Lock waits", database.lock_waiting_queries ?? "—", `slow active ${database.slow_active_queries ?? "—"}`, O.n(database.lock_waiting_queries) ? "bad" : "good"),
+        ].join("");
+
+        O.$("queueCards").innerHTML = [
+          O.metric("Total queue depth", queueDepth, "Redis/Celery LLEN total", queueTone(queueDepth)),
+          O.metric("Worker service", queue.worker_service?.status || "unknown", queue.worker_service?.enabled || "systemd", O.statusClass(queue.worker_service?.status)),
+          O.metric("Beat service", queue.beat_service?.status || "unknown", queue.beat_service?.enabled || "systemd", O.statusClass(queue.beat_service?.status)),
+        ].join("");
+        O.bars("queueBars", Object.entries(queues).map(([name, q]) => ({ label: name, value: O.n(q.depth), tone: queueTone(q.depth) })));
+
+        O.$("deployCards").innerHTML = [
+          O.metric("Branch", deployment.current_branch || deployment.branch || "unknown", "current deployed branch", "good"),
+          O.metric("SHA", deployment.short_sha || latest.deploy?.short_sha || "—", deployment.is_dirty || latest.deploy?.is_dirty ? "working tree dirty" : "clean working tree", deployment.is_dirty || latest.deploy?.is_dirty ? "warn" : "good"),
+          O.metric("Last commit", deployment.last_commit_message || "—", "deployment metadata", "good"),
+          O.metric("Uptime", O.fmtUptime(server.uptime_seconds), `${heartbeat.hostname || server.hostname || "host"}`, "good"),
+        ].join("");
+
+        O.$("incidentList").innerHTML = incidentRows.length ? incidentRows.map(i => O.statusRow(i.title, i.severity, `${i.source || "unknown"} · ${O.ago(i.started_at)}`)).join("") : O.statusRow("No open incidents", "live", "clear");
+        O.$("backupCards").innerHTML = [
+          O.metric("Backup status", backup.status || "unknown", "latest detected backup", backupTone(backup.status, backup.latest_backup_age_hours)),
+          O.metric("Backup age", backup.latest_backup_age_hours != null ? `${backup.latest_backup_age_hours}h` : "—", backup.latest_backup_path || "no path", backupTone(backup.status, backup.latest_backup_age_hours)),
+          O.metric("Matched files", backup.matched_files ?? "—", "backup scan count", "good"),
+        ].join("");
+      } catch (err) {
+        O.$("error").textContent = `Unable to load NOC data: ${err && err.message ? err.message : err}`;
+        O.$("error").style.display = "block";
+      } finally {
+        O.$("refreshBtn").disabled = false;
+      }
+    }
+
+    O.$("refreshBtn").addEventListener("click", load);
+    load();
+    setInterval(load, 60000);
+  </script>
+</body>
+</html>

--- a/apps/dashboard/public/ops-page/ops-page.css
+++ b/apps/dashboard/public/ops-page/ops-page.css
@@ -1,0 +1,157 @@
+:root {
+  color-scheme: dark;
+  --bg: #08111f;
+  --panel: rgba(15, 23, 42, 0.88);
+  --panel-soft: rgba(30, 41, 59, 0.64);
+  --text: #e5eefc;
+  --muted: #94a3b8;
+  --line: rgba(148, 163, 184, 0.2);
+  --good: #22c55e;
+  --warn: #f59e0b;
+  --bad: #ef4444;
+  --unknown: #64748b;
+  --accent: #38bdf8;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(56, 189, 248, 0.14), transparent 36rem),
+    radial-gradient(circle at top right, rgba(34, 197, 94, 0.1), transparent 34rem),
+    var(--bg);
+  color: var(--text);
+}
+
+main { width: min(1440px, calc(100% - 32px)); margin: 0 auto; padding: 32px 0 56px; }
+
+.hero,
+.card,
+.metric {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+}
+
+.hero {
+  border-radius: 28px;
+  padding: 28px;
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1 { margin: 0; font-size: clamp(34px, 4vw, 62px); line-height: 0.95; letter-spacing: -0.06em; }
+h2 { margin: 0; font-size: 26px; letter-spacing: -0.03em; }
+h3 { margin: 0; font-size: 18px; }
+p { color: var(--muted); }
+.subtitle { max-width: 940px; line-height: 1.7; }
+
+.nav { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 18px; }
+.nav a,
+button {
+  color: var(--text);
+  border: 1px solid var(--line);
+  background: rgba(15, 23, 42, 0.82);
+  border-radius: 999px;
+  padding: 10px 13px;
+  text-decoration: none;
+  font-weight: 700;
+  cursor: pointer;
+}
+.nav a:hover,
+button:hover { border-color: rgba(56, 189, 248, 0.55); }
+button:disabled { opacity: 0.65; cursor: wait; }
+
+.section { margin-top: 24px; }
+.section-head { margin-bottom: 14px; }
+.grid { display: grid; gap: 14px; }
+.metrics { grid-template-columns: repeat(6, minmax(0, 1fr)); }
+.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.four { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+
+.metric {
+  border-radius: 22px;
+  padding: 18px;
+  min-height: 132px;
+}
+.metric p { margin: 0 0 10px; font-size: 13px; }
+.metric strong { display: block; font-size: 30px; letter-spacing: -0.05em; }
+.metric span { display: block; margin-top: 8px; color: var(--muted); font-size: 12px; line-height: 1.45; }
+.metric.good { border-color: rgba(34, 197, 94, 0.4); }
+.metric.warn { border-color: rgba(245, 158, 11, 0.52); }
+.metric.bad { border-color: rgba(239, 68, 68, 0.58); }
+.metric.unknown { border-color: rgba(100, 116, 139, 0.58); }
+
+.card { border-radius: 22px; padding: 18px; }
+.card-head { display: flex; justify-content: space-between; gap: 12px; align-items: start; margin-bottom: 16px; }
+
+.pill { display: inline-flex; border: 1px solid var(--line); border-radius: 999px; padding: 4px 9px; font-size: 11px; font-weight: 800; color: var(--muted); }
+.pill.good { color: var(--good); border-color: rgba(34, 197, 94, 0.35); background: rgba(34, 197, 94, 0.08); }
+.pill.warn { color: var(--warn); border-color: rgba(245, 158, 11, 0.35); background: rgba(245, 158, 11, 0.08); }
+.pill.bad { color: var(--bad); border-color: rgba(239, 68, 68, 0.35); background: rgba(239, 68, 68, 0.08); }
+.pill.unknown { color: var(--unknown); }
+
+.bars { display: grid; gap: 10px; }
+.bar-row { display: grid; grid-template-columns: minmax(120px, 250px) 1fr 70px; gap: 10px; align-items: center; }
+.bar-label { color: var(--muted); font-size: 12px; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.bar-track { height: 10px; border-radius: 999px; background: rgba(148, 163, 184, 0.14); overflow: hidden; }
+.bar-fill { height: 100%; border-radius: 999px; background: var(--accent); }
+.bar-fill.good { background: var(--good); }
+.bar-fill.warn { background: var(--warn); }
+.bar-fill.bad { background: var(--bad); }
+.bar-value { text-align: right; font-size: 12px; font-weight: 800; }
+
+.spark-box { border: 1px solid var(--line); border-radius: 16px; padding: 12px; background: rgba(15, 23, 42, 0.42); }
+.spark-head { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 10px; }
+.spark-head span { color: var(--muted); font-size: 12px; font-weight: 800; }
+.spark { width: 100%; height: 52px; }
+.spark polyline { fill: none; stroke: var(--accent); stroke-width: 2.4; vector-effect: non-scaling-stroke; }
+.spark.good polyline { stroke: var(--good); }
+.spark.warn polyline { stroke: var(--warn); }
+.spark.bad polyline { stroke: var(--bad); }
+
+.status-list { display: grid; gap: 10px; }
+.status-row { display: flex; gap: 10px; padding: 12px; border: 1px solid var(--line); border-radius: 16px; background: rgba(15, 23, 42, 0.45); }
+.status-row strong { display: block; }
+.status-row p { margin: 4px 0 0; font-size: 12px; }
+.dot { width: 10px; height: 10px; border-radius: 999px; margin-top: 5px; background: var(--unknown); flex: 0 0 auto; }
+.dot.good { background: var(--good); box-shadow: 0 0 0 5px rgba(34, 197, 94, 0.12); }
+.dot.warn { background: var(--warn); box-shadow: 0 0 0 5px rgba(245, 158, 11, 0.12); }
+.dot.bad { background: var(--bad); box-shadow: 0 0 0 5px rgba(239, 68, 68, 0.12); }
+
+.table-wrap { overflow: auto; border: 1px solid var(--line); border-radius: 16px; }
+table { width: 100%; border-collapse: collapse; min-width: 980px; }
+th, td { text-align: left; padding: 12px; border-bottom: 1px solid var(--line); font-size: 13px; }
+th { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; }
+code { color: #bae6fd; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+
+.banner { display: none; border: 1px solid rgba(239, 68, 68, 0.45); background: rgba(239, 68, 68, 0.1); color: #fecaca; padding: 14px 16px; border-radius: 18px; margin-top: 18px; }
+.muted { color: var(--muted); }
+.small { font-size: 12px; }
+
+@media (max-width: 1100px) {
+  .metrics { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .two, .three, .four { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 680px) {
+  main { width: min(100% - 20px, 1440px); padding-top: 14px; }
+  .hero { flex-direction: column; padding: 20px; border-radius: 22px; }
+  .metrics { grid-template-columns: 1fr; }
+  .bar-row { grid-template-columns: 120px 1fr 50px; }
+}

--- a/apps/dashboard/public/ops-page/ops-page.js
+++ b/apps/dashboard/public/ops-page/ops-page.js
@@ -1,0 +1,87 @@
+const OpsPage = (() => {
+  const API_BASE = window.OPS_ENGINE_API_BASE || localStorage.getItem("OPS_ENGINE_API_BASE") || "https://ops-engine-api.ishan4rs.workers.dev/api";
+  const $ = (id) => document.getElementById(id);
+  const n = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
+  const asArray = (value) => Array.isArray(value) ? value : [];
+  const parseJson = (value, fallback) => {
+    if (typeof value !== "string") return value || fallback;
+    try { return JSON.parse(value); } catch { return fallback; }
+  };
+  const esc = (value) => String(value ?? "").replace(/[&<>'"]/g, ch => ({"&":"&amp;","<":"&lt;",">":"&gt;","'":"&#39;","\"":"&quot;"}[ch]));
+  const ago = (iso) => {
+    if (!iso) return "never";
+    const diff = Date.now() - new Date(iso).getTime();
+    if (!Number.isFinite(diff)) return "unknown";
+    const sec = Math.max(0, Math.round(diff / 1000));
+    if (sec < 60) return `${sec}s ago`;
+    const min = Math.round(sec / 60);
+    if (min < 60) return `${min}m ago`;
+    const hr = Math.round(min / 60);
+    if (hr < 48) return `${hr}h ago`;
+    return `${Math.round(hr / 24)}d ago`;
+  };
+  const fmtBytes = (bytes) => {
+    const b = n(bytes, -1);
+    if (b < 0) return "—";
+    if (b < 1024 * 1024) return `${Math.round(b / 1024)} KB`;
+    if (b < 1024 ** 3) return `${(b / 1024 ** 2).toFixed(1)} MB`;
+    return `${(b / 1024 ** 3).toFixed(2)} GB`;
+  };
+  const fmtUptime = (seconds) => {
+    const s = n(seconds, -1);
+    if (s < 0) return "—";
+    const d = Math.floor(s / 86400), h = Math.floor((s % 86400) / 3600), m = Math.floor((s % 3600) / 60);
+    return d ? `${d}d ${h}h` : h ? `${h}h ${m}m` : `${m}m`;
+  };
+  const statusClass = (value) => {
+    const s = String(value || "unknown").toLowerCase();
+    if (["healthy","ok","active","running","online","live","enabled"].includes(s)) return "good";
+    if (["degraded","warning","pending","stale","stale-warning","partial"].includes(s)) return "warn";
+    if (["critical","failed","down","inactive","error","missing","disabled"].includes(s)) return "bad";
+    const code = Number(s);
+    if (Number.isFinite(code)) return code >= 500 ? "bad" : code >= 400 ? "warn" : "good";
+    return "unknown";
+  };
+  const metric = (title, value, detail, tone = "") => `<div class="metric ${tone}"><p>${esc(title)}</p><strong>${esc(value)}</strong><span>${esc(detail || "")}</span></div>`;
+  const statusRow = (name, status, detail) => `<article class="status-row"><span class="dot ${statusClass(status)}"></span><div><strong>${esc(name)}</strong><p>${esc(status)}${detail ? " · " + esc(detail) : ""}</p></div></article>`;
+  const bars = (id, rows) => {
+    const el = $(id); if (!el) return;
+    const data = rows.length ? rows : [{ label: "none", value: 0 }];
+    const max = Math.max(...data.map(x => n(x.value)), 1);
+    el.innerHTML = data.map(row => `<div class="bar-row"><span class="bar-label" title="${esc(row.label)}">${esc(row.label)}</span><div class="bar-track"><div class="bar-fill ${row.tone || ""}" style="width:${Math.max(2, n(row.value) / max * 100)}%"></div></div><span class="bar-value">${esc(row.value)}</span></div>`).join("");
+  };
+  const downsample = (values, maxPoints = 48) => {
+    const nums = asArray(values).map(Number).filter(Number.isFinite);
+    if (nums.length <= maxPoints) return nums;
+    const bucket = nums.length / maxPoints;
+    const out = [];
+    for (let i = 0; i < maxPoints; i += 1) {
+      const start = Math.floor(i * bucket);
+      const end = Math.max(start + 1, Math.floor((i + 1) * bucket));
+      const slice = nums.slice(start, end);
+      out.push(Number((slice.reduce((a, b) => a + b, 0) / slice.length).toFixed(2)));
+    }
+    return out;
+  };
+  const spark = (id, label, values, tone = "", suffix = "") => {
+    const el = $(id); if (!el) return;
+    const raw = asArray(values).map(Number).filter(Number.isFinite);
+    const nums = downsample(raw, 48);
+    const latest = raw.length ? raw[raw.length - 1] : 0;
+    const max = Math.max(...nums, 1), min = Math.min(...nums, 0), span = Math.max(1, max - min);
+    const points = nums.length ? nums.map((v, i) => `${(i / Math.max(1, nums.length - 1)) * 100},${44 - ((v - min) / span) * 34}`).join(" ") : "0,44 100,44";
+    el.innerHTML = `<div class="spark-box"><div class="spark-head"><strong>${esc(label)}</strong><span>${raw.length ? `${latest}${suffix}` : "0"}</span></div><svg class="spark ${tone}" viewBox="0 0 100 52" preserveAspectRatio="none"><polyline points="${points}"></polyline></svg></div>`;
+  };
+  const getJson = async (path) => {
+    const response = await fetch(`${API_BASE}${path}`, { cache: "no-store" });
+    if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
+    return response.json();
+  };
+  const loadBundle = async () => {
+    const [latest, services, history, incidents, errors] = await Promise.all([
+      getJson("/status/latest"), getJson("/services"), getJson("/history"), getJson("/incidents"), getJson("/errors"),
+    ]);
+    return { latest, services, history, incidents, errors };
+  };
+  return { API_BASE, $, n, asArray, parseJson, esc, ago, fmtBytes, fmtUptime, statusClass, metric, statusRow, bars, spark, getJson, loadBundle };
+})();

--- a/docs/NOC_DASHBOARD.md
+++ b/docs/NOC_DASHBOARD.md
@@ -1,0 +1,134 @@
+# NOC Dashboard
+
+Ops Engine exposes a dedicated Network Operations Center dashboard at:
+
+```text
+https://ops-engine.pages.dev/NOC
+```
+
+The NOC dashboard is intentionally separate from the main mission-control dashboard and the SOC dashboard.
+
+## Purpose
+
+The NOC dashboard focuses on availability, infrastructure health, service health, and operational response.
+
+SOC answers:
+
+```text
+Are we being attacked or probed?
+```
+
+NOC answers:
+
+```text
+Is production healthy and available?
+```
+
+## Route implementation
+
+The route is implemented as a Cloudflare Pages static asset:
+
+```text
+apps/dashboard/public/NOC/index.html
+```
+
+Shared static page helpers live in:
+
+```text
+apps/dashboard/public/ops-page/ops-page.css
+apps/dashboard/public/ops-page/ops-page.js
+```
+
+This follows the incremental refactor direction: reusable shared helpers for standalone operational pages, without forcing a full React router refactor yet.
+
+## Data source
+
+The NOC page reads from the existing Worker API:
+
+```text
+https://ops-engine-api.ishan4rs.workers.dev/api
+```
+
+It uses:
+
+```text
+GET /api/status/latest
+GET /api/services
+GET /api/history
+GET /api/incidents
+GET /api/errors
+```
+
+## NOC coverage
+
+The dashboard surfaces:
+
+- NOC risk score
+- SMW health status
+- disk usage
+- memory usage
+- Celery/Redis queue depth
+- open incidents
+- server load trends
+- request and 5xx trends
+- recent uptime checks
+- systemd and PM2 service snapshots
+- PostgreSQL connections, size, lock waits, and slow active query count
+- worker and beat service state
+- deployment branch/SHA/dirty state
+- backup age and backup status
+
+## Privacy boundary
+
+NOC should not show private student data, raw request bodies, cookies, auth headers, raw email content, or payment card data.
+
+NOC is allowed to display operational aggregates and service-level metadata such as service names, status, resource percentages, queue depth, backup age, deployment SHA, database aggregate stats, and uptime result summaries.
+
+## Local validation
+
+```bash
+cd apps/dashboard
+npm install
+npm run build
+npm run preview
+```
+
+Open:
+
+```text
+http://127.0.0.1:4173/NOC/
+```
+
+Validate the Worker API directly if needed:
+
+```bash
+curl -s https://ops-engine-api.ishan4rs.workers.dev/api/status/latest | python3 -m json.tool
+curl -s https://ops-engine-api.ishan4rs.workers.dev/api/services | python3 -m json.tool
+curl -s https://ops-engine-api.ishan4rs.workers.dev/api/history | python3 -m json.tool
+```
+
+## Production validation
+
+After Cloudflare Pages deploys from `main`, check:
+
+```text
+https://ops-engine.pages.dev/NOC
+```
+
+Hard refresh if needed:
+
+```text
+Ctrl + Shift + R
+```
+
+## Future improvements
+
+Recommended follow-ups:
+
+- convert Mission Control, SOC, and NOC into shared React page components
+- add `/api/noc/summary` if server-side NOC aggregation becomes necessary
+- add incident acknowledgement and maintenance-window states
+- add backup freshness alert thresholds per environment
+- add deploy comparison against expected branch/SHA
+- add Cloudflare Analytics data for edge availability and latency
+- protect all operational pages with Cloudflare Access


### PR DESCRIPTION
## Summary

- Add a dedicated `/NOC` dashboard route for Network Operations Center monitoring.
- Add reusable static page helpers under `apps/dashboard/public/ops-page/` so NOC and future standalone operational pages do not need to duplicate all CSS/JS.
- Document the NOC dashboard route, data sources, validation steps, and future improvements.

## Implementation

New files:

```text
apps/dashboard/public/ops-page/ops-page.css
apps/dashboard/public/ops-page/ops-page.js
apps/dashboard/public/NOC/index.html
docs/NOC_DASHBOARD.md
```

Cloudflare Pages should serve:

```text
https://ops-engine.pages.dev/NOC
```

## NOC coverage

The NOC dashboard surfaces:

- NOC risk score
- SMW health status
- disk and memory usage
- Celery/Redis queue depth
- open incidents
- server resource trends
- uptime checks
- request and 5xx trends
- systemd and PM2 service health
- PostgreSQL aggregate health
- worker/beat health
- deployment branch/SHA/dirty state
- backup age/status

## Data source

Uses existing Worker API endpoints:

```text
GET /api/status/latest
GET /api/services
GET /api/history
GET /api/incidents
GET /api/errors
```

## Validation

```bash
cd apps/dashboard
npm install
npm run build
```

After Cloudflare Pages deployment:

```text
https://ops-engine.pages.dev/NOC
```
