### PR TITLE
Tune SOC risk scoring and risk-hint display

### DIFF
--- a/apps/dashboard/public/SOC/index.html
+++ b/apps/dashboard/public/SOC/index.html
@@ -5,86 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SMW SOC Dashboard | Ops Engine</title>
   <style>
-    :root {
-      color-scheme: dark;
-      --bg: #08111f;
-      --panel: rgba(15, 23, 42, 0.88);
-      --panel2: rgba(30, 41, 59, 0.68);
-      --text: #e5eefc;
-      --muted: #94a3b8;
-      --line: rgba(148, 163, 184, 0.2);
-      --good: #22c55e;
-      --warn: #f59e0b;
-      --bad: #ef4444;
-      --accent: #38bdf8;
-      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      background: radial-gradient(circle at top left, rgba(56,189,248,.15), transparent 36rem), radial-gradient(circle at top right, rgba(239,68,68,.12), transparent 34rem), var(--bg);
-      color: var(--text);
-    }
-    main { width: min(1440px, calc(100% - 32px)); margin: 0 auto; padding: 32px 0 56px; }
-    .hero, .card, .metric { border: 1px solid var(--line); background: var(--panel); box-shadow: 0 24px 80px rgba(0,0,0,.28); }
-    .hero { border-radius: 28px; padding: 28px; display: flex; justify-content: space-between; gap: 20px; align-items: flex-start; }
-    .eyebrow { margin: 0 0 8px; color: var(--accent); font-size: 12px; font-weight: 800; letter-spacing: .16em; text-transform: uppercase; }
-    h1 { margin: 0; font-size: clamp(34px, 4vw, 62px); line-height: .95; letter-spacing: -.06em; }
-    h2 { margin: 0; font-size: 26px; letter-spacing: -.03em; }
-    h3 { margin: 0; font-size: 18px; }
-    p { color: var(--muted); }
-    .subtitle { max-width: 900px; line-height: 1.7; }
-    .nav { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 18px; }
-    .nav a, button { color: var(--text); border: 1px solid var(--line); background: rgba(15,23,42,.8); border-radius: 999px; padding: 10px 13px; text-decoration: none; font-weight: 700; cursor: pointer; }
-    button:disabled { opacity: .65; cursor: wait; }
-    .section { margin-top: 24px; }
-    .section-head { margin-bottom: 14px; }
-    .grid { display: grid; gap: 14px; }
-    .metrics { grid-template-columns: repeat(6, minmax(0, 1fr)); }
-    .two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
-    .metric { border-radius: 22px; padding: 18px; min-height: 132px; }
-    .metric p { margin: 0 0 10px; font-size: 13px; }
-    .metric strong { display: block; font-size: 30px; letter-spacing: -.05em; }
-    .metric span { display: block; margin-top: 8px; color: var(--muted); font-size: 12px; line-height: 1.45; }
-    .metric.good { border-color: rgba(34,197,94,.4); }
-    .metric.warn { border-color: rgba(245,158,11,.52); }
-    .metric.bad { border-color: rgba(239,68,68,.58); }
-    .card { border-radius: 22px; padding: 18px; }
-    .card-head { display: flex; justify-content: space-between; gap: 12px; align-items: start; margin-bottom: 16px; }
-    .bars { display: grid; gap: 10px; }
-    .bar-row { display: grid; grid-template-columns: minmax(120px, 250px) 1fr 60px; gap: 10px; align-items: center; }
-    .bar-label { color: var(--muted); font-size: 12px; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
-    .bar-track { height: 10px; border-radius: 999px; background: rgba(148,163,184,.14); overflow: hidden; }
-    .bar-fill { height: 100%; border-radius: 999px; background: var(--accent); }
-    .bar-fill.good { background: var(--good); }
-    .bar-fill.warn { background: var(--warn); }
-    .bar-fill.bad { background: var(--bad); }
-    .bar-value { text-align: right; font-size: 12px; font-weight: 800; }
-    .pill { display: inline-flex; border: 1px solid var(--line); border-radius: 999px; padding: 4px 9px; font-size: 11px; font-weight: 800; color: var(--muted); }
-    .pill.good { color: var(--good); border-color: rgba(34,197,94,.35); background: rgba(34,197,94,.08); }
-    .pill.warn { color: var(--warn); border-color: rgba(245,158,11,.35); background: rgba(245,158,11,.08); }
-    .pill.bad { color: var(--bad); border-color: rgba(239,68,68,.35); background: rgba(239,68,68,.08); }
-    .risk-band { height: 14px; border-radius: 999px; background: linear-gradient(90deg, var(--good), var(--warn), var(--bad)); position: relative; overflow: hidden; margin-top: 14px; }
-    .risk-marker { position: absolute; top: -3px; width: 4px; height: 20px; background: white; border-radius: 999px; box-shadow: 0 0 20px rgba(255,255,255,.8); }
-    .table-wrap { overflow: auto; border: 1px solid var(--line); border-radius: 16px; }
-    table { width: 100%; border-collapse: collapse; min-width: 980px; }
-    th, td { text-align: left; padding: 12px; border-bottom: 1px solid var(--line); font-size: 13px; }
-    th { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
-    code { color: #bae6fd; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
-    .status-list { display: grid; gap: 10px; }
-    .status-row { display: flex; gap: 10px; padding: 12px; border: 1px solid var(--line); border-radius: 16px; background: rgba(15,23,42,.45); }
-    .status-row strong { display: block; }
-    .status-row p { margin: 4px 0 0; font-size: 12px; }
-    .dot { width: 10px; height: 10px; border-radius: 999px; margin-top: 5px; background: #64748b; flex: 0 0 auto; }
-    .dot.good { background: var(--good); box-shadow: 0 0 0 5px rgba(34,197,94,.12); }
-    .dot.warn { background: var(--warn); box-shadow: 0 0 0 5px rgba(245,158,11,.12); }
-    .dot.bad { background: var(--bad); box-shadow: 0 0 0 5px rgba(239,68,68,.12); }
-    .banner { display: none; border: 1px solid rgba(239,68,68,.45); background: rgba(239,68,68,.1); color: #fecaca; padding: 14px 16px; border-radius: 18px; margin-top: 18px; }
-    .muted { color: var(--muted); }
-    .small { font-size: 12px; }
-    @media (max-width: 1100px) { .metrics { grid-template-columns: repeat(3, minmax(0, 1fr)); } .two, .three { grid-template-columns: 1fr; } }
-    @media (max-width: 680px) { main { width: min(100% - 20px, 1440px); padding-top: 14px; } .hero { flex-direction: column; padding: 20px; border-radius: 22px; } .metrics { grid-template-columns: 1fr; } }
+    :root{color-scheme:dark;--bg:#08111f;--panel:rgba(15,23,42,.9);--panel2:rgba(30,41,59,.72);--text:#e5eefc;--muted:#94a3b8;--line:rgba(148,163,184,.22);--good:#22c55e;--warn:#f59e0b;--bad:#ef4444;--accent:#38bdf8;--violet:#a78bfa;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}*{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at top left,rgba(56,189,248,.16),transparent 36rem),radial-gradient(circle at top right,rgba(239,68,68,.12),transparent 34rem),var(--bg);color:var(--text)}main{width:min(1440px,calc(100% - 32px));margin:0 auto;padding:32px 0 56px}.hero,.card,.metric{border:1px solid var(--line);background:var(--panel);box-shadow:0 24px 80px rgba(0,0,0,.28)}.hero{border-radius:28px;padding:28px;display:flex;justify-content:space-between;gap:20px;align-items:flex-start}.eyebrow{margin:0 0 8px;color:var(--accent);font-size:12px;font-weight:800;letter-spacing:.16em;text-transform:uppercase}h1{margin:0;font-size:clamp(34px,4vw,62px);line-height:.95;letter-spacing:-.06em}h2{margin:0;font-size:26px;letter-spacing:-.03em}h3{margin:0;font-size:18px}p{color:var(--muted)}.subtitle{max-width:940px;line-height:1.7}.nav{display:flex;gap:8px;flex-wrap:wrap;margin-top:18px}.nav a,button{color:var(--text);border:1px solid var(--line);background:rgba(15,23,42,.8);border-radius:999px;padding:10px 13px;text-decoration:none;font-weight:700;cursor:pointer}.section{margin-top:24px}.section-head{margin-bottom:14px}.grid{display:grid;gap:14px}.metrics{grid-template-columns:repeat(6,minmax(0,1fr))}.two{grid-template-columns:repeat(2,minmax(0,1fr))}.three{grid-template-columns:repeat(3,minmax(0,1fr))}.metric{border-radius:22px;padding:18px;min-height:132px}.metric p{margin:0 0 10px;font-size:13px}.metric strong{display:block;font-size:30px;letter-spacing:-.05em}.metric span{display:block;margin-top:8px;color:var(--muted);font-size:12px;line-height:1.45}.metric.good{border-color:rgba(34,197,94,.4)}.metric.warn{border-color:rgba(245,158,11,.52)}.metric.bad{border-color:rgba(239,68,68,.58)}.metric.info{border-color:rgba(56,189,248,.42)}.card{border-radius:22px;padding:18px}.card-head{display:flex;justify-content:space-between;gap:12px;align-items:start;margin-bottom:16px}.bars{display:grid;gap:10px}.bar-row{display:grid;grid-template-columns:minmax(120px,260px) 1fr 60px;gap:10px;align-items:center}.bar-label{color:var(--muted);font-size:12px;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}.bar-track{height:10px;border-radius:999px;background:rgba(148,163,184,.14);overflow:hidden}.bar-fill{height:100%;border-radius:999px;background:var(--accent)}.bar-fill.good{background:var(--good)}.bar-fill.warn{background:var(--warn)}.bar-fill.bad{background:var(--bad)}.bar-fill.info{background:var(--violet)}.bar-value{text-align:right;font-size:12px;font-weight:800}.pill{display:inline-flex;border:1px solid var(--line);border-radius:999px;padding:4px 9px;font-size:11px;font-weight:800;color:var(--muted)}.pill.good{color:var(--good);border-color:rgba(34,197,94,.35);background:rgba(34,197,94,.08)}.pill.warn{color:var(--warn);border-color:rgba(245,158,11,.35);background:rgba(245,158,11,.08)}.pill.bad{color:var(--bad);border-color:rgba(239,68,68,.35);background:rgba(239,68,68,.08)}.pill.info{color:var(--accent);border-color:rgba(56,189,248,.35);background:rgba(56,189,248,.08)}.risk-band{height:14px;border-radius:999px;background:linear-gradient(90deg,var(--good),var(--warn),var(--bad));position:relative;overflow:hidden;margin-top:14px}.risk-marker{position:absolute;top:-3px;width:4px;height:20px;background:white;border-radius:999px;box-shadow:0 0 20px rgba(255,255,255,.8)}.action{display:grid;gap:8px;border:1px solid var(--line);background:rgba(15,23,42,.52);border-radius:18px;padding:14px;margin-top:14px}.action strong{font-size:20px}.table-wrap{overflow:auto;border:1px solid var(--line);border-radius:16px}table{width:100%;border-collapse:collapse;min-width:1120px}th,td{text-align:left;padding:12px;border-bottom:1px solid var(--line);font-size:13px}th{color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.08em}code{color:#bae6fd;font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace}.status-list{display:grid;gap:10px}.status-row{display:flex;gap:10px;padding:12px;border:1px solid var(--line);border-radius:16px;background:rgba(15,23,42,.45)}.status-row strong{display:block}.status-row p{margin:4px 0 0;font-size:12px}.dot{width:10px;height:10px;border-radius:999px;margin-top:5px;background:#64748b;flex:0 0 auto}.dot.good{background:var(--good);box-shadow:0 0 0 5px rgba(34,197,94,.12)}.dot.warn{background:var(--warn);box-shadow:0 0 0 5px rgba(245,158,11,.12)}.dot.bad{background:var(--bad);box-shadow:0 0 0 5px rgba(239,68,68,.12)}.banner{display:none;border:1px solid rgba(239,68,68,.45);background:rgba(239,68,68,.1);color:#fecaca;padding:14px 16px;border-radius:18px;margin-top:18px}.muted{color:var(--muted)}.small{font-size:12px}@media(max-width:1100px){.metrics{grid-template-columns:repeat(3,minmax(0,1fr))}.two,.three{grid-template-columns:1fr}}@media(max-width:680px){main{width:min(100% - 20px,1440px);padding-top:14px}.hero{flex-direction:column;padding:20px;border-radius:22px}.metrics{grid-template-columns:1fr}}
   </style>
 </head>
 <body>
@@ -93,14 +14,11 @@
       <div>
         <p class="eyebrow">Security Operations Center</p>
         <h1>SMW SOC Dashboard</h1>
-        <p class="subtitle">Security-focused monitoring for sunnysir.com using Ops Engine telemetry: sanitized request events, hashed actor signals, fail2ban/nginx summaries, API anomalies, incidents, uptime, and Sentry-lite error groups.</p>
-        <nav class="nav">
-          <a href="/">Mission Control</a><a href="/SOC">SOC</a><a href="#signals">Signals</a><a href="#requests">Suspicious Requests</a><a href="#incidents">Incidents</a><a href="#privacy">Privacy</a>
-        </nav>
+        <p class="subtitle">Security-focused monitoring for sunnysir.com using Ops Engine telemetry. The scoring now treats ordinary failed scanner probes as lower-risk background noise and weighs admin probes, server errors, slow abuse, incidents, and fail2ban actions higher.</p>
+        <nav class="nav"><a href="/">Overview</a><a href="/SOC">SOC</a><a href="/NOC">NOC</a><a href="/GRC">GRC</a><a href="#signals">Signals</a><a href="#requests">Suspicious Requests</a><a href="#privacy">Privacy</a></nav>
       </div>
       <button id="refreshBtn">↻ Refresh</button>
     </header>
-
     <div id="error" class="banner"></div>
 
     <section class="section" id="overview">
@@ -109,17 +27,21 @@
     </section>
 
     <section class="section" id="signals">
-      <div class="section-head"><p class="eyebrow">Detection signals</p><h2>Traffic and actor signals</h2></div>
-      <div class="grid two">
+      <div class="section-head"><p class="eyebrow">Detection signals</p><h2>Traffic, route, and actor signals</h2></div>
+      <div class="grid three">
+        <div class="card"><div class="card-head"><div><p class="eyebrow">Risk hints</p><h3>SMW classified events</h3></div></div><div class="bars" id="riskHintBars"></div></div>
         <div class="card"><div class="card-head"><div><p class="eyebrow">HTTP status</p><h3>Status code distribution</h3></div></div><div class="bars" id="statusBars"></div></div>
-        <div class="card"><div class="card-head"><div><p class="eyebrow">Actor role</p><h3>Request roles</h3></div></div><div class="bars" id="roleBars"></div></div>
+        <div class="card"><div class="card-head"><div><p class="eyebrow">Route group</p><h3>Route groups</h3></div></div><div class="bars" id="routeBars"></div></div>
       </div>
-      <div class="card" style="margin-top:14px"><div class="card-head"><div><p class="eyebrow">Endpoint pressure</p><h3>Most active endpoints</h3></div></div><div class="bars" id="endpointBars"></div></div>
+      <div class="grid two" style="margin-top:14px">
+        <div class="card"><div class="card-head"><div><p class="eyebrow">Actor role</p><h3>Request roles</h3></div></div><div class="bars" id="roleBars"></div></div>
+        <div class="card"><div class="card-head"><div><p class="eyebrow">Endpoint pressure</p><h3>Most active endpoints</h3></div></div><div class="bars" id="endpointBars"></div></div>
+      </div>
     </section>
 
     <section class="section" id="requests">
-      <div class="section-head"><p class="eyebrow">Investigation queue</p><h2>Suspicious recent requests</h2><p class="small muted">Shows sampled requests with HTTP 4xx/5xx or duration ≥ 1000ms. Identifiers are hashed.</p></div>
-      <div class="card"><div class="table-wrap"><table><thead><tr><th>Time</th><th>Request ID</th><th>Method</th><th>Endpoint</th><th>Status</th><th>Duration</th><th>Role</th><th>User Hash</th><th>IP Hash</th></tr></thead><tbody id="requestRows"><tr><td colspan="9">Loading…</td></tr></tbody></table></div></div>
+      <div class="section-head"><p class="eyebrow">Investigation queue</p><h2>Suspicious recent requests</h2><p class="small muted">Shows sampled requests with non-none risk hints, HTTP 4xx/5xx, or duration ≥ 1000ms. Identifiers are hashed.</p></div>
+      <div class="card"><div class="table-wrap"><table><thead><tr><th>Time</th><th>Risk</th><th>Request ID</th><th>Method</th><th>Endpoint</th><th>Status</th><th>Duration</th><th>Role</th><th>User Hash</th><th>IP Hash</th></tr></thead><tbody id="requestRows"><tr><td colspan="10">Loading…</td></tr></tbody></table></div></div>
     </section>
 
     <section class="section" id="incidents">
@@ -142,149 +64,84 @@
 
   <script>
     const API_BASE = window.OPS_ENGINE_API_BASE || localStorage.getItem("OPS_ENGINE_API_BASE") || "https://ops-engine-api.ishan4rs.workers.dev/api";
-    const $ = (id) => document.getElementById(id);
+    const $ = id => document.getElementById(id);
     const n = (value, fallback = 0) => Number.isFinite(Number(value)) ? Number(value) : fallback;
-    const asArray = (value) => Array.isArray(value) ? value : [];
+    const asArray = value => Array.isArray(value) ? value : [];
     const parseJson = (value, fallback) => { if (typeof value !== "string") return value || fallback; try { return JSON.parse(value); } catch { return fallback; } };
-    const esc = (value) => String(value ?? "").replace(/[&<>'"]/g, ch => ({"&":"&amp;","<":"&lt;",">":"&gt;","'":"&#39;","\"":"&quot;"}[ch]));
-    const ago = (iso) => {
-      if (!iso) return "never";
-      const diff = Date.now() - new Date(iso).getTime();
-      if (!Number.isFinite(diff)) return "unknown";
-      const sec = Math.max(0, Math.round(diff / 1000));
-      if (sec < 60) return `${sec}s ago`;
-      const min = Math.round(sec / 60);
-      if (min < 60) return `${min}m ago`;
-      const hr = Math.round(min / 60);
-      if (hr < 48) return `${hr}h ago`;
-      return `${Math.round(hr / 24)}d ago`;
-    };
-    const statusClass = (value) => {
-      const s = String(value || "unknown").toLowerCase();
-      if (["healthy","ok","active","running","online","live","enabled"].includes(s)) return "good";
-      if (["degraded","warning","pending","stale","partial"].includes(s)) return "warn";
-      if (["critical","failed","down","inactive","error","missing","disabled"].includes(s)) return "bad";
-      const code = Number(s);
-      if (Number.isFinite(code)) return code >= 500 ? "bad" : code >= 400 ? "warn" : "good";
-      return "unknown";
-    };
-    function mergeCounts(...sources) {
-      const out = {};
-      for (const source of sources) {
-        for (const [key, value] of Object.entries(source || {})) out[key] = n(out[key]) + n(value);
-      }
-      return out;
+    const esc = value => String(value ?? "").replace(/[&<>'"]/g, ch => ({"&":"&amp;","<":"&lt;",">":"&gt;","'":"&#39;","\"":"&quot;"}[ch]));
+    const ago = iso => { if (!iso) return "never"; const diff = Date.now() - new Date(iso).getTime(); if (!Number.isFinite(diff)) return "unknown"; const sec = Math.max(0, Math.round(diff / 1000)); if (sec < 60) return `${sec}s ago`; const min = Math.round(sec / 60); if (min < 60) return `${min}m ago`; const hr = Math.round(min / 60); if (hr < 48) return `${hr}h ago`; return `${Math.round(hr / 24)}d ago`; };
+    const statusClass = value => { const s = String(value || "unknown").toLowerCase(); if (["healthy","ok","active","running","online","live","enabled","observe"].includes(s)) return "good"; if (["degraded","warning","pending","stale","partial","review","challenge"].includes(s)) return "warn"; if (["critical","failed","down","inactive","error","missing","disabled","block"].includes(s)) return "bad"; const code = Number(s); if (Number.isFinite(code)) return code >= 500 ? "bad" : code >= 400 ? "warn" : "good"; return "info"; };
+    const metaOf = ev => ev && typeof ev.metadata === "object" ? ev.metadata : parseJson(ev?.metadata_json, {});
+    function mergeCounts(...sources){ const out = {}; for (const source of sources){ for (const [key,value] of Object.entries(source || {})) out[key] = n(out[key]) + n(value); } return out; }
+    function countFromEvents(events, getter){ const counts = {}; for (const ev of events){ const key = getter(ev); if (!key) continue; counts[key] = n(counts[key]) + 1; } return counts; }
+    function statusFamilyTotal(counts, floor, ceiling){ return Object.entries(counts || {}).reduce((sum,[status,count]) => { const code = Number(status); return Number.isFinite(code) && code >= floor && code < ceiling ? sum + n(count) : sum; },0); }
+    function toneForRiskHint(hint){ return hint === "server_error" ? "bad" : hint === "admin_probe" || hint === "slow_request" ? "warn" : hint === "scanner_probe" ? "info" : "good"; }
+    function metric(title,value,detail,tone=""){ return `<div class="metric ${tone}"><p>${esc(title)}</p><strong>${esc(value)}</strong><span>${esc(detail || "")}</span></div>`; }
+    function bars(id, rows){ const data = rows.length ? rows : [{label:"none",value:0,tone:"good"}]; const max = Math.max(...data.map(x => n(x.value)),1); $(id).innerHTML = data.map(row => `<div class="bar-row"><span class="bar-label" title="${esc(row.label)}">${esc(row.label)}</span><div class="bar-track"><div class="bar-fill ${row.tone || ""}" style="width:${Math.max(2,n(row.value)/max*100)}%"></div></div><span class="bar-value">${esc(row.value)}</span></div>`).join(""); }
+    function statusRow(name,status,detail){ return `<article class="status-row"><span class="dot ${statusClass(status)}"></span><div><strong>${esc(name)}</strong><p>${esc(status)}${detail ? " · " + esc(detail) : ""}</p></div></article>`; }
+    async function getJson(path){ const response = await fetch(`${API_BASE}${path}`, {cache:"no-store"}); if (!response.ok) throw new Error(`${response.status} ${response.statusText}`); return response.json(); }
+    function recommendedAction({riskScore, scannerProbe, adminProbe, serverError, slowRequest, total5xx, fail2banBans, incidents, errorGroups}){
+      if (incidents || total5xx >= 3 || serverError >= 3) return {label:"Investigate incident", tone:"bad", detail:"Server errors or incidents are present. Check backend error groups and recent deploys before blocking actors."};
+      if (adminProbe >= 10 || fail2banBans >= 3) return {label:"Challenge or temporary block", tone:"warn", detail:"Repeated admin probing or fail2ban activity detected. Consider Cloudflare challenge first, then temporary block if repeated."};
+      if (adminProbe > 0 || slowRequest >= 5 || riskScore >= 55) return {label:"Review", tone:"warn", detail:"Some higher-risk signals exist. Review actor hashes and endpoint pattern before taking action."};
+      if (scannerProbe > 0) return {label:"Observe", tone:"good", detail:"Current activity looks like failed scanner noise. All sampled probes failed; no raw IP/action bridge needed yet."};
+      return {label:"Clear", tone:"good", detail:"No meaningful suspicious signals in the latest sample."};
     }
-    function countStatusesFromEvents(events) {
-      const counts = {};
-      for (const ev of events) {
-        const status = n(ev.status);
-        if (!status) continue;
-        counts[String(status)] = n(counts[String(status)]) + 1;
-      }
-      return counts;
-    }
-    function countRolesFromEvents(events) {
-      const counts = {};
-      for (const ev of events) {
-        const role = String(ev.role || "unknown");
-        counts[role] = n(counts[role]) + 1;
-      }
-      return counts;
-    }
-    function countEndpointsFromEvents(events) {
-      const counts = {};
-      for (const ev of events) {
-        const endpoint = String(ev.endpoint || "unknown");
-        counts[endpoint] = n(counts[endpoint]) + 1;
-      }
-      return Object.entries(counts).sort((a, b) => b[1] - a[1]).map(([endpoint, count]) => ({ endpoint, count }));
-    }
-    function statusFamilyTotal(counts, floor, ceiling) {
-      return Object.entries(counts || {}).reduce((sum, [status, count]) => {
-        const code = Number(status);
-        return Number.isFinite(code) && code >= floor && code < ceiling ? sum + n(count) : sum;
-      }, 0);
-    }
-    function metric(title, value, detail, tone = "") {
-      return `<div class="metric ${tone}"><p>${esc(title)}</p><strong>${esc(value)}</strong><span>${esc(detail || "")}</span></div>`;
-    }
-    function bars(id, rows) {
-      const data = rows.length ? rows : [{ label: "none", value: 0 }];
-      const max = Math.max(...data.map(x => n(x.value)), 1);
-      $(id).innerHTML = data.map(row => `<div class="bar-row"><span class="bar-label" title="${esc(row.label)}">${esc(row.label)}</span><div class="bar-track"><div class="bar-fill ${row.tone || ""}" style="width:${Math.max(2, n(row.value) / max * 100)}%"></div></div><span class="bar-value">${esc(row.value)}</span></div>`).join("");
-    }
-    function statusRow(name, status, detail) {
-      return `<article class="status-row"><span class="dot ${statusClass(status)}"></span><div><strong>${esc(name)}</strong><p>${esc(status)}${detail ? " · " + esc(detail) : ""}</p></div></article>`;
-    }
-    async function getJson(path) {
-      const response = await fetch(`${API_BASE}${path}`, { cache: "no-store" });
-      if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
-      return response.json();
-    }
-    async function load() {
-      $("refreshBtn").disabled = true;
-      $("error").style.display = "none";
-      try {
+    async function load(){
+      $("refreshBtn").disabled = true; $("error").style.display = "none";
+      try{
         const [latest, errors] = await Promise.all([getJson("/status/latest"), getJson("/errors")]);
-        const heartbeat = latest.heartbeat || {};
-        const cc = latest.control_center || {};
-        const security = cc.security || {};
-        const api = latest.api_traffic || {};
-        const requestSummary = latest.request_summary || {};
-        const requestEvents = asArray(latest.request_events);
-        const incidents = asArray(latest.incidents);
-        const errorGroups = asArray(errors.error_groups);
-
-        const apiStatusCounts = parseJson(api.status_codes_json, {});
-        const eventStatusCounts = countStatusesFromEvents(requestEvents);
-        const statusCounts = mergeCounts(apiStatusCounts, eventStatusCounts);
-        const roleCounts = mergeCounts(parseJson(requestSummary.roles_json, {}), countRolesFromEvents(requestEvents));
+        const heartbeat = latest.heartbeat || {}, cc = latest.control_center || {}, security = cc.security || {}, api = latest.api_traffic || {}, requestSummary = latest.request_summary || {};
+        const requestEvents = asArray(latest.request_events), incidents = asArray(latest.incidents), errorGroups = asArray(errors.error_groups);
+        const apiStatusCounts = parseJson(api.status_codes_json, {}), summaryStatuses = parseJson(requestSummary.statuses_json, {});
+        const eventStatusCounts = countFromEvents(requestEvents, ev => String(ev.status || ""));
+        const statusCounts = mergeCounts(apiStatusCounts, summaryStatuses.codes || {}, eventStatusCounts);
+        const roleCounts = mergeCounts(parseJson(requestSummary.roles_json, {}), countFromEvents(requestEvents, ev => String(ev.role || "unknown")));
+        const routeCounts = mergeCounts(summaryStatuses.route_groups || {}, countFromEvents(requestEvents, ev => String(metaOf(ev).route_group || "unknown")));
+        const riskHintCounts = mergeCounts(summaryStatuses.risk_hints || {}, countFromEvents(requestEvents, ev => String(metaOf(ev).risk_hint || "none")));
         const endpointRows = asArray(parseJson(requestSummary.endpoints_json, []));
-        const eventEndpointRows = countEndpointsFromEvents(requestEvents);
+        const eventEndpointRows = Object.entries(countFromEvents(requestEvents, ev => String(ev.endpoint || "unknown"))).sort((a,b)=>b[1]-a[1]).map(([endpoint,count])=>({endpoint,count}));
         const endpointSource = endpointRows.length ? endpointRows : eventEndpointRows;
-
-        const total4xx = Math.max(n(api.total_4xx), statusFamilyTotal(statusCounts, 400, 500));
-        const total5xx = Math.max(n(api.total_5xx), statusFamilyTotal(statusCounts, 500, 600));
-        const fail2banBans = n(security.fail2ban_bans);
-        const nginxErrors = n(security.nginx_error_lines);
-        const suspicious = requestEvents.filter(ev => n(ev.status) >= 400 || n(ev.duration_ms) >= 1000);
-        const probingPenalty = Math.min(30, suspicious.length);
-        const riskScore = Math.min(100, total5xx * 10 + total4xx * 2 + fail2banBans * 15 + nginxErrors * 2 + incidents.length * 20 + errorGroups.length * 5 + probingPenalty);
-        const riskTone = riskScore >= 70 ? "bad" : riskScore >= 30 ? "warn" : "good";
-
+        const total4xx = Math.max(n(api.total_4xx), statusFamilyTotal(statusCounts,400,500));
+        const total5xx = Math.max(n(api.total_5xx), statusFamilyTotal(statusCounts,500,600));
+        const scannerProbe = n(riskHintCounts.scanner_probe), adminProbe = n(riskHintCounts.admin_probe), serverError = n(riskHintCounts.server_error), slowRequest = n(riskHintCounts.slow_request);
+        const fail2banBans = n(security.fail2ban_bans), nginxErrors = n(security.nginx_error_lines);
+        const suspicious = requestEvents.filter(ev => { const m = metaOf(ev); return String(m.risk_hint || "none") !== "none" || n(ev.status) >= 400 || n(ev.duration_ms) >= 1000; });
+        const scoreParts = {
+          scanner: Math.min(scannerProbe * 2, 25),
+          admin: Math.min(adminProbe * 8, 40),
+          server: serverError * 15,
+          slow: Math.min(slowRequest * 5, 25),
+          generic5xx: total5xx * 15,
+          fail2ban: fail2banBans * 20,
+          nginx: Math.min(nginxErrors * 2, 20),
+          incidents: incidents.length * 25,
+          errorGroups: errorGroups.length * 8,
+        };
+        const riskScore = Math.min(100, Object.values(scoreParts).reduce((a,b)=>a+n(b),0));
+        const riskTone = riskScore >= 70 ? "bad" : riskScore >= 35 ? "warn" : "good";
+        const action = recommendedAction({riskScore, scannerProbe, adminProbe, serverError, slowRequest, total5xx, fail2banBans, incidents: incidents.length, errorGroups: errorGroups.length});
         $("heartbeatMeta").textContent = `Heartbeat ${ago(heartbeat.received_at)} · Source ${heartbeat.source || "unknown"} · API ${API_BASE}`;
         $("metrics").innerHTML = [
-          metric("SOC risk score", `${riskScore}/100`, "Uses aggregate traffic plus recent request-event probes.", riskTone),
-          metric("Fail2ban bans", fail2banBans, `${security.fail2ban_events || 0} fail2ban events`, fail2banBans > 0 ? "warn" : "good"),
-          metric("API 4xx", total4xx, `${suspicious.length} suspicious sampled requests`, total4xx > 50 ? "bad" : total4xx > 0 ? "warn" : "good"),
-          metric("API 5xx", total5xx, "Server-side failure pressure", total5xx > 0 ? "bad" : "good"),
-          metric("Nginx errors", nginxErrors, "Edge/server error lines", nginxErrors > 0 ? "warn" : "good"),
-          metric("Error groups", errorGroups.length, "Sentry-lite groups", errorGroups.length > 0 ? "bad" : "good"),
-        ].join("") + `<div class="card" style="grid-column:1/-1"><div class="card-head"><div><p class="eyebrow">Risk band</p><h3>Current SOC posture</h3></div><span class="pill ${riskTone}">${riskTone.toUpperCase()}</span></div><div class="risk-band"><span class="risk-marker" style="left:calc(${riskScore}% - 2px)"></span></div></div>`;
-
-        bars("statusBars", Object.entries(statusCounts).sort((a,b) => Number(a[0]) - Number(b[0])).map(([label, value]) => ({ label, value: n(value), tone: n(label) >= 500 ? "bad" : n(label) >= 400 ? "warn" : "good" })));
-        bars("roleBars", Object.entries(roleCounts).map(([label, value]) => ({ label, value: n(value), tone: label === "anonymous" ? "warn" : "good" })));
-        bars("endpointBars", endpointSource.slice(0, 12).map(item => ({ label: String(item.endpoint || item.path || "unknown"), value: n(item.count), tone: "good" })));
-
-        $("requestRows").innerHTML = suspicious.length ? suspicious.map(ev => `<tr><td>${esc(ago(ev.ts))}</td><td><code>${esc(ev.request_id || "—")}</code></td><td>${esc(ev.method || "")}</td><td><code>${esc(ev.endpoint || "")}</code></td><td><span class="pill ${statusClass(ev.status)}">${esc(ev.status)}</span></td><td>${esc(ev.duration_ms)}ms</td><td>${esc(ev.role || "")}</td><td><code>${esc(ev.hashed_user_id || "—")}</code></td><td><code>${esc(ev.hashed_ip || "—")}</code></td></tr>`).join("") : `<tr><td colspan="9">No suspicious requests in the latest sample.</td></tr>`;
+          metric("SOC risk score", `${riskScore}/100`, "Risk-hint aware score. Scanner probes are capped as background noise.", riskTone),
+          metric("Scanner probes", scannerProbe, "Failed scanner-like probes such as wp-admin/swagger/credentials.", scannerProbe ? "info" : "good"),
+          metric("Admin probes", adminProbe, "Admin or secret-admin probing signals.", adminProbe ? "warn" : "good"),
+          metric("Server errors", total5xx + serverError, "5xx and server_error risk hints.", total5xx + serverError ? "bad" : "good"),
+          metric("Fail2ban bans", fail2banBans, `${security.fail2ban_events || 0} fail2ban events`, fail2banBans ? "warn" : "good"),
+          metric("Error groups", errorGroups.length, "Sentry-lite groups", errorGroups.length ? "bad" : "good"),
+        ].join("") + `<div class="card" style="grid-column:1/-1"><div class="card-head"><div><p class="eyebrow">Risk band</p><h3>Current SOC posture</h3></div><span class="pill ${riskTone}">${riskTone.toUpperCase()}</span></div><div class="risk-band"><span class="risk-marker" style="left:calc(${riskScore}% - 2px)"></span></div><div class="action"><span class="pill ${action.tone}">Recommended action</span><strong>${esc(action.label)}</strong><p>${esc(action.detail)}</p></div></div>`;
+        bars("riskHintBars", Object.entries(riskHintCounts).sort((a,b)=>b[1]-a[1]).map(([label,value])=>({label,value:n(value),tone:toneForRiskHint(label)})));
+        bars("statusBars", Object.entries(statusCounts).sort((a,b)=>Number(a[0])-Number(b[0])).map(([label,value])=>({label,value:n(value),tone:n(label)>=500?"bad":n(label)>=400?"warn":"good"})));
+        bars("routeBars", Object.entries(routeCounts).sort((a,b)=>b[1]-a[1]).map(([label,value])=>({label,value:n(value),tone:label==="legal"?"info":"good"})));
+        bars("roleBars", Object.entries(roleCounts).map(([label,value])=>({label,value:n(value),tone:label==="anonymous"?"warn":"good"})));
+        bars("endpointBars", endpointSource.slice(0,12).map(item=>({label:String(item.endpoint || item.path || "unknown"),value:n(item.count),tone:"good"})));
+        $("requestRows").innerHTML = suspicious.length ? suspicious.map(ev => { const m = metaOf(ev); const risk = String(m.risk_hint || "none"); return `<tr><td>${esc(ago(ev.ts))}</td><td><span class="pill ${toneForRiskHint(risk)}">${esc(risk)}</span></td><td><code>${esc(ev.request_id || "—")}</code></td><td>${esc(ev.method || "")}</td><td><code>${esc(ev.endpoint || "")}</code></td><td><span class="pill ${statusClass(ev.status)}">${esc(ev.status)}</span></td><td>${esc(ev.duration_ms)}ms</td><td>${esc(ev.role || "")}</td><td><code>${esc(ev.hashed_user_id || "—")}</code></td><td><code>${esc(ev.hashed_ip || "—")}</code></td></tr>`; }).join("") : `<tr><td colspan="10">No suspicious requests in the latest sample.</td></tr>`;
         $("incidentList").innerHTML = incidents.length ? incidents.map(i => statusRow(i.title, i.severity, `${i.source || "unknown"} · ${ago(i.started_at)}`)).join("") : statusRow("No open incidents", "live", "clear");
-        $("errorList").innerHTML = errorGroups.length ? errorGroups.slice(0, 10).map(group => {
-          const meta = parseJson(group.metadata_json, {});
-          const name = meta.exception_class || group.fingerprint || "Error group";
-          const detail = `${group.latest_path || meta.file || "unknown location"} · count ${group.count || 0} · ${ago(group.last_seen)}`;
-          return statusRow(name, group.latest_severity || "error", detail);
-        }).join("") : statusRow("No error groups", "live", "clear");
-      } catch (err) {
-        $("error").textContent = `Unable to load SOC data: ${err && err.message ? err.message : err}`;
-        $("error").style.display = "block";
-      } finally {
-        $("refreshBtn").disabled = false;
-      }
+        $("errorList").innerHTML = errorGroups.length ? errorGroups.slice(0,10).map(group => { const meta = parseJson(group.metadata_json, {}); const name = meta.exception_class || group.fingerprint || "Error group"; const detail = `${group.latest_path || meta.file || "unknown location"} · count ${group.count || 0} · ${ago(group.last_seen)}`; return statusRow(name, group.latest_severity || "error", detail); }).join("") : statusRow("No error groups", "live", "clear");
+      }catch(err){ $("error").textContent = `Unable to load SOC data: ${err && err.message ? err.message : err}`; $("error").style.display = "block"; }
+      finally{ $("refreshBtn").disabled = false; }
     }
-    $("refreshBtn").addEventListener("click", load);
-    load();
-    setInterval(load, 60000);
+    $("refreshBtn").addEventListener("click", load); load(); setInterval(load, 60000);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Tunes SOC risk scoring so ordinary scanner probes are treated as lower-risk background noise instead of immediately pushing the score near critical.
- Adds first-class risk-hint cards/bars for `scanner_probe`, `admin_probe`, `server_error`, and `slow_request`.
- Adds route-group visibility to the SOC signals section.
- Adds a recommended-action panel:
  - Observe for failed scanner-only activity
  - Review for mixed higher-risk signals
  - Challenge/block recommendation for repeated admin probing/fail2ban activity
  - Investigate incident for server errors/incidents
- Updates the suspicious request table to show each event's risk hint.
- Adds consistent global links to Overview, SOC, NOC, and GRC.

## Why

The previous SOC score treated all 4xx pressure too aggressively. This made normal internet scanner noise look like a severe incident even when there were no 5xx errors, no incidents, no fail2ban bans, no nginx errors, and no backend error groups.

## Validation

After merge and Pages redeploy:

```bash
curl -s https://ops-engine-api.ishan4rs.workers.dev/api/status/latest | python3 -m json.tool
```

Then open:

```text
https://ops-engine.pages.dev/SOC
```

Expected: scanner-only activity should recommend `Observe` and show a lower score than before.
