### PR TITLE
Update dashboard and SOC documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Ops Engine intentionally lives outside the main SMW Django project. It gives SWE
 
 | Component | URL |
 |---|---|
-| Dashboard | `https://ops-engine.pages.dev` |
+| Mission Control dashboard | `https://ops-engine.pages.dev/` |
+| SOC dashboard | `https://ops-engine.pages.dev/SOC` |
+| NOC dashboard | `https://ops-engine.pages.dev/NOC` |
+| GRC dashboard | `https://ops-engine.pages.dev/GRC` |
 | Worker API | `https://ops-engine-api.ishan4rs.workers.dev/api` |
 | SMW public site | `https://sunnysir.com` |
 | SMW private health bridge | `https://sunnysir.com/api/internal/health-summary/` |
@@ -63,7 +66,7 @@ Cloudflare Worker
   └─ exposes dashboard API
 
 Cloudflare Pages dashboard
-  └─ reads Worker API and renders mission-control UI
+  └─ reads Worker API and renders Mission Control, SOC, NOC, and GRC pages
 ```
 
 Important: the droplet agent **pushes data out**. The SMW droplet should not expose a public monitoring port.
@@ -84,23 +87,39 @@ ops-engine/
 
 ---
 
-## Dashboard sections
+## Dashboard routes and navigation
 
-The dashboard is section-based and includes top navigation:
+Current dashboard routes:
 
 ```text
-Overview | Trends | Traffic | Database | Queue | Security | UX | Business | Incidents
+/      = Mission Control
+/SOC   = Security Operations Center
+/NOC   = Network Operations Center
+/GRC   = Governance, Risk, and Compliance readiness
 ```
 
-Target dashboard separation:
+All operational dashboard pages should expose the same top-level navigation:
 
 ```text
-Overview = all traffic, including normal 2xx responses
-SOC      = suspicious patterns, findings, investigations, and response actions
-NOC      = infrastructure and service health
-GRC      = compliance and audit evidence
-Logs     = searchable sanitized events
-Settings = thresholds, allowlists, integrations, and response policy
+Mission Control | SOC | NOC | GRC
+```
+
+Mission Control is implemented by the Vite/React shell. The separate `/SOC`, `/NOC`, and `/GRC` pages are static Cloudflare Pages folder-index routes under `apps/dashboard/public/`.
+
+Mission Control still contains section-level operational cards/tables for production health, trends, traffic, database, queue, security, UX, business, incidents, and errors. The dedicated pages split those concerns into clearer operational modes:
+
+```text
+Mission Control = broad executive/SRE overview
+SOC             = suspicious patterns, risk hints, findings, investigations, and response guidance
+NOC             = infrastructure, service health, uptime, queues, backups, and production availability
+GRC             = compliance readiness, audit evidence signals, backup/deploy/service controls
+```
+
+Future routes may include:
+
+```text
+/Logs      = searchable sanitized events
+/Settings  = thresholds, allowlists, integrations, and response policy
 ```
 
 Current live coverage:
@@ -159,6 +178,28 @@ slow_request
 ```
 
 Important: these are event hints, not automatic blocking decisions. SOC should aggregate them into findings and response recommendations.
+
+---
+
+## SOC scoring note
+
+The SOC dashboard uses a risk-hint-aware score. Scanner-only 404 noise should usually recommend `Observe`, not an automatic block.
+
+Current scoring weights:
+
+```text
+scanner_probe: +2 each, capped at +25
+admin_probe: +8 each, capped at +40
+server_error: +15 each
+slow_request: +5 each, capped at +25
+5xx: +15 each
+fail2ban bans: +20 each
+nginx error lines: +2 each, capped at +20
+open incidents: +25 each
+error groups: +8 each
+```
+
+Fail2ban counts are useful SOC context, but the current aggregate can include SSH and HTTP/nginx jails. A future improvement should expose per-jail fail2ban counters so SOC can weigh `nginx-sensitive-probes` differently from `sshd`.
 
 ---
 
@@ -326,6 +367,15 @@ Deploy from `main`. After deployment, hard refresh the browser:
 
 ```text
 Ctrl + Shift + R
+```
+
+Validate all dashboard routes:
+
+```text
+https://ops-engine.pages.dev/
+https://ops-engine.pages.dev/SOC
+https://ops-engine.pages.dev/NOC
+https://ops-engine.pages.dev/GRC
 ```
 
 ---
@@ -565,6 +615,17 @@ sudo systemctl start ops-engine-agent.service
 sudo journalctl -u ops-engine-agent -n 80 --no-pager
 ```
 
+### Inspect fail2ban jails on the droplet
+
+```bash
+sudo fail2ban-client status
+sudo fail2ban-client status sshd
+sudo fail2ban-client status nginx-sensitive-probes
+sudo fail2ban-client status nginx-botsearch
+sudo fail2ban-client status nginx-http-auth
+sudo grep -Ei "nginx-sensitive-probes|nginx-botsearch|nginx-http-auth|sshd|Ban|Unban|Found|Ignore" /var/log/fail2ban.log | tail -n 120
+```
+
 ### Clean fake/noisy error groups manually
 
 Only for known bad fingerprints:
@@ -707,7 +768,8 @@ Planned next improvements:
 - incident acknowledgement workflow
 - dashboard authentication/protection
 - custom domain such as `ops.sunnysir.com`
-- SOC/NOC/GRC/Logs dashboard split with shared switcher
+- Logs/Settings dashboard split with shared switcher
+- per-jail fail2ban counters and weighting
 - request risk-hint aggregation and SOC findings
 - private droplet-agent/Cloudflare response bridge
 - richer Telegram alert formatting

--- a/docs/SOC_DASHBOARD.md
+++ b/docs/SOC_DASHBOARD.md
@@ -6,7 +6,32 @@ Ops Engine exposes a dedicated Security Operations Center dashboard at:
 https://ops-engine.pages.dev/SOC
 ```
 
-The SOC dashboard is intentionally separate from the main mission-control dashboard. The main dashboard remains focused on production, SRE, database, queue, UX, and business health. The SOC dashboard focuses on security triage and incident investigation.
+The SOC dashboard is intentionally separate from the main Mission Control dashboard. Mission Control remains focused on broad production, SRE, database, queue, UX, and business health. SOC focuses on security triage, suspicious traffic, risk hints, fail2ban/security signals, and incident investigation.
+
+## Current production navigation
+
+All operational dashboards should link to each other with a shared top-level dashboard switcher:
+
+```text
+Mission Control | SOC | NOC | GRC
+```
+
+Current routes:
+
+```text
+/      = Mission Control
+/SOC   = Security Operations Center
+/NOC   = Network Operations Center
+/GRC   = Governance, Risk, and Compliance readiness
+```
+
+The SOC page also exposes intra-page links:
+
+```text
+Signals | Suspicious Requests | Privacy
+```
+
+The 2026-05-13 deployed SOC screenshot confirms that the SOC page shows the global dashboard links and marks `SOC` as active.
 
 ## Route implementation
 
@@ -39,11 +64,101 @@ The dashboard consumes the same sanitized data already pushed by the SMW droplet
 - nginx error-line summaries
 - API 4xx and 5xx counts
 - status-code distributions
+- route-group distributions
 - request-role distributions
+- risk-hint distributions
 - top endpoint pressure
 - open incidents
 - Sentry-lite backend/Celery error groups
 - sampled request events with hashed identifiers only
+
+## Request risk hints
+
+SMW emits lightweight `risk_hint` values in sanitized request telemetry. Current values:
+
+```text
+none
+scanner_probe
+admin_probe
+server_error
+slow_request
+```
+
+SOC treats these as triage hints, not automatic blocking decisions.
+
+Current interpretation:
+
+| Risk hint | Meaning | Default action |
+|---|---|---|
+| `none` | No known suspicious pattern | No action |
+| `scanner_probe` | Common scanner path such as wp-admin, swagger, credentials, config, etc. | Observe unless repeated/heavy |
+| `admin_probe` | Admin or secret-admin probing pattern | Review; challenge/block only if repeated |
+| `server_error` | Backend/server-side failure signal | Investigate |
+| `slow_request` | Request exceeded slow threshold | Review for abuse/performance issue |
+
+## SOC scoring model
+
+The SOC score is risk-hint aware. It should avoid treating ordinary one-off internet scanner noise as a critical incident.
+
+Current scoring behavior:
+
+```text
+scanner_probe: +2 each, capped at +25
+admin_probe: +8 each, capped at +40
+server_error: +15 each
+slow_request: +5 each, capped at +25
+5xx: +15 each
+fail2ban bans: +20 each
+nginx error lines: +2 each, capped at +20
+open incidents: +25 each
+error groups: +8 each
+```
+
+Recommended action logic:
+
+```text
+Clear        = no meaningful suspicious signals
+Observe      = failed scanner-only activity
+Review       = mixed higher-risk signals, admin probe, slow abuse, or score >= 55
+Challenge    = repeated admin probing or fail2ban activity
+Investigate  = incidents, repeated server errors, or significant 5xx activity
+```
+
+## Fail2ban interpretation note
+
+The current agent exposes aggregate fail2ban event and ban counts. This may include SSH activity, nginx-sensitive-probe activity, nginx botsearch activity, or other jail activity depending on the logs seen inside the agent window.
+
+Important implication:
+
+```text
+Fail2ban bans are useful SOC context, but they do not always mean the web application is under active HTTP attack.
+```
+
+If the SOC score becomes elevated mainly because of fail2ban bans, verify which jail caused them on the droplet:
+
+```bash
+sudo fail2ban-client status
+sudo fail2ban-client status sshd
+sudo fail2ban-client status nginx-sensitive-probes
+sudo fail2ban-client status nginx-botsearch
+sudo fail2ban-client status nginx-http-auth
+sudo grep -Ei "nginx-sensitive-probes|nginx-botsearch|nginx-http-auth|sshd|Ban|Unban|Found|Ignore" /var/log/fail2ban.log | tail -n 120
+```
+
+Recommended future improvement:
+
+```text
+Expose per-jail fail2ban counters from the agent so SOC can weigh nginx/http bans higher and sshd bans lower.
+```
+
+Suggested future weighting:
+
+```text
+nginx-sensitive-probes ban: +20 each
+nginx-botsearch ban: +10 each
+nginx-http-auth ban: +10 each
+sshd ban: +3 each, capped at +15
+```
 
 ## Privacy boundary
 
@@ -64,8 +179,10 @@ Allowed SOC fields include:
 - hashed user ID
 - user role
 - normalized endpoint path
+- route group
+- risk hint
 - method
-- status code
+- status code and status family
 - request duration
 - request ID
 - incident metadata
@@ -112,10 +229,24 @@ Hard refresh the browser if needed:
 Ctrl + Shift + R
 ```
 
+Expected visible items:
+
+- global dashboard links: `Mission Control | SOC | NOC | GRC`
+- SOC active navigation state
+- SOC risk score
+- scanner/admin/server/fail2ban/error cards
+- risk-hint bars
+- status-code bars
+- route-group bars
+- suspicious request table with `Risk` column
+- incidents/error groups
+- privacy boundary cards
+
 ## Future improvements
 
 Recommended follow-up improvements:
 
+- split fail2ban counters by jail in the agent and Worker response
 - move SOC UI into React components after the main dashboard is split into reusable components
 - add `/api/security/summary` in the Worker if SOC-specific server-side aggregation becomes necessary
 - add incident acknowledgement and analyst notes


### PR DESCRIPTION
## Summary

- Updates README with current production dashboard routes:
  - Mission Control
  - SOC
  - NOC
  - GRC
- Documents the shared dashboard navigation expectation across pages.
- Updates SOC documentation with:
  - current global navigation
  - risk-hint interpretation
  - current SOC scoring model
  - recommended action logic
  - fail2ban interpretation and per-jail follow-up recommendation
  - deployment validation expectations
- Adds fail2ban inspection commands to common operations.
- Updates roadmap to reflect Logs/Settings as future dashboard routes and per-jail fail2ban counters as a follow-up.

## Validation

Docs-only change.

Recommended after merge:

```bash
cd apps/dashboard
npm run build
```

Then check:

```text
https://ops-engine.pages.dev/
https://ops-engine.pages.dev/SOC
https://ops-engine.pages.dev/NOC
https://ops-engine.pages.dev/GRC
```
